### PR TITLE
Added explicitCheck as a backward-compatible extension to support onBlur.

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ import Joi from "joi"
 import { useValidator } from "react-joi"
 
 function App() {
-    const { state, setData, validate } = useValidator({
+    const { state, setData, setExplicitField, validate } = useValidator({
         initialData: {
             name: null,
             email: null,
@@ -40,6 +40,10 @@ function App() {
                 })
                 .required(),
         }),
+	    explicitCheck: {
+        	name: false,
+            email: false
+        }
     })
 
     const updateName = (e) => {
@@ -67,7 +71,7 @@ function App() {
             <div>
                 <label>Name</label>
                 <br />
-                <input type="text" onChange={updateName} />
+                <input type="text" onChange={updateName} onBlur={() => setExplicitField('name', true)} />
                 <br />
                 {state.$errors.name.map((data) => data.$message).join(",")}
 
@@ -76,7 +80,7 @@ function App() {
 
                 <label>Email</label>
                 <br />
-                <input type="text" onChange={updateEmail} />
+                <input type="text" onChange={updateEmail} onBlur={() => setExplicitField('email', true) />
                 <br />
                 {state.$errors.email.map((data) => data.$message).join(",")}
 
@@ -101,7 +105,9 @@ function App() {
 
 ![](https://i.ibb.co/93wndgy/image.png)
 
-
+Note that the explicitCheck object is optional, and is only needed if it is desired to suppress error messages during
+input until the onBlur method has fired at least once. If this behavior is not required/desired, then omit it as shown
+in the second example.
 
 ## State Documentation
 
@@ -109,6 +115,7 @@ function App() {
 | --------------------- | ------------------------------------------------------------ |
 | `$data`               | Values of the instance                                       |
 | `$dirty`              | Dirty state of the instance                                  |
+| `$explicitfields`     | Settings of any fields that have been explicitly set         |
 | `$data_state`         | State of the values: `$dirty` means if the initial data is touched or not |
 | `$source_errors`      | Raw errors of the instance. This re-validates every time `$data` is changed regardless of `$dirty` is `true` or `false` |
 | `$errors`             | `Recommended` way of retrieving errors of each fields. Each fields respects global `$dirty` state of the instance and `$data_state`'s `$dirty` states. |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "react-joi",
-    "version": "0.0.6",
+    "version": "0.0.5",
     "description": "",
     "main": "index.js",
     "scripts": {
@@ -16,14 +16,14 @@
     ],
     "repository": {
         "type": "git",
-        "url": "git+https://github.com/llesslie/react-joi.git"
+        "url": "git+https://github.com/thihathit/react-joi.git"
     },
     "author": "Thiha Thit",
     "license": "MIT",
     "bugs": {
-        "url": "https://github.com/llesslie/react-joi/issues"
+        "url": "https://github.com/thihathit/react-joi/issues"
     },
-    "homepage": "https://github.com/llesslie/react-joi#readme",
+    "homepage": "https://github.com/thihathit/react-joi#readme",
     "peerDependencies": {
         "joi": "^17.3.0",
         "react": "^17.0.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "react-joi",
-    "version": "0.0.5",
+    "version": "0.0.6",
     "description": "",
     "main": "index.js",
     "scripts": {
@@ -16,14 +16,14 @@
     ],
     "repository": {
         "type": "git",
-        "url": "git+https://github.com/thihathit/react-joi.git"
+        "url": "git+https://github.com/llesslie/react-joi.git"
     },
     "author": "Thiha Thit",
     "license": "MIT",
     "bugs": {
-        "url": "https://github.com/thihathit/react-joi/issues"
+        "url": "https://github.com/llesslie/react-joi/issues"
     },
-    "homepage": "https://github.com/thihathit/react-joi#readme",
+    "homepage": "https://github.com/llesslie/react-joi#readme",
     "peerDependencies": {
         "joi": "^17.3.0",
         "react": "^17.0.1"


### PR DESCRIPTION
I needed a way to allow form validation to utilize the onBlur method to allow users to input data without receiving any error messages until navigating away from the field. So I added an explicit check field that allows validation to specify the fields it wishes to explicitly enable, typically using onBlur. To utilize this, the useValidator method accepts a new explicitCheck object which should be populated with the fields that should not be marked as dirty even if changed. This object is simple, and should look like:

explicitCheck: {
	field1: false,
	field2: false
}

Any field that appears in this object and is set to false will not be marked as dirty, though it will still be validated as usual. The form should enable displaying errors by calling the new function setExplicitField, which is returned by the object created by useValidator. This works like the following:

<input onBlur={ () => setExplicitField(‘field1’, true) } …/>

I think this provides a convenient option for users. Note that the change is backward-compatible with the existing interface, and does not require any changes to code currently using this hook. I updated the README documentation to describe its usage.