### PR TITLE
Change error output by splitting it into array of messages

### DIFF
--- a/index.js
+++ b/index.js
@@ -53,13 +53,15 @@ export const useValidator = ({ initialData, schema, explicitCheck = {} }) => {
         const fields = Array.from(schema._ids._byKey.keys())
         fields.map((field) => {
             const messages = []
-            const error = schema.extract(field).validate($data[field]).error
+            const errors = schema.extract(field).validate($data[field], {abortEarly: false}).error;
 
-            if (error) {
-                messages.push({
-                    $property: field,
-                    $message: error.message,
-                })
+            if(errors && errors.details) {
+                errors.details.map(err => {
+                    messages.push({
+                        $property: field,
+                        $message: err.message,
+                    })
+                });
             }
 
             results[field] = messages


### PR DESCRIPTION
Hello. I tried validating using your library but found out that only one error for single field is displaying. I did not find how to get all errors so I made a few changes in your code. I don't think this is worse because it still returns array as before, but now the array can contain all errors. I made it for myself but if you find my code useful, please, merge it.